### PR TITLE
fix(telegram): httpx is required

### DIFF
--- a/drivers/telegram.py
+++ b/drivers/telegram.py
@@ -32,6 +32,10 @@ import io
 from typing import TypedDict
 from urllib.parse import urlencode
 
+# Runtime import (not TYPE_CHECKING): httpx.Proxy / httpx.URL are referenced in
+# the _HTTPXRequestCommonKwargs annotation below, which is evaluated at import
+# time, so removing this import would raise NameError. httpx is a hard dependency
+# (declared in pyproject and required by python-telegram-bot).
 import httpx
 from PIL import Image, UnidentifiedImageError
 from telegram import LinkPreviewOptions, ReplyParameters, Update
@@ -68,6 +72,9 @@ def _patch_httpcore_proxy_tunnel():
     See: https://github.com/encode/httpcore/discussions/921
     """
     try:
+        # async_mod / sync_mod re-export httpcore's Request / Response types, so
+        # the patched handlers' annotations below stay aligned with httpcore
+        # without needing a separate (TYPE_CHECKING) httpcore import.
         import httpcore._async.http_proxy as async_mod
         import httpcore._sync.http_proxy as sync_mod
     except ImportError:

--- a/drivers/telegram.py
+++ b/drivers/telegram.py
@@ -29,9 +29,10 @@
 import asyncio
 import html
 import io
-from typing import TYPE_CHECKING, TypedDict
+from typing import TypedDict
 from urllib.parse import urlencode
 
+import httpx
 from PIL import Image, UnidentifiedImageError
 from telegram import LinkPreviewOptions, ReplyParameters, Update
 from telegram.error import TelegramError
@@ -45,10 +46,6 @@ from services import media
 from services.config import UNSET, get_proxy
 from services.config_schema import _DriverConfig
 from services.message import Attachment, NormalizedMessage
-
-if TYPE_CHECKING:
-    import httpcore
-    import httpx
 
 
 class _HTTPXRequestCommonKwargs(TypedDict, total=False):
@@ -80,8 +77,8 @@ def _patch_httpcore_proxy_tunnel():
 
     async def _patched_async_handle(
         self: async_mod.AsyncTunnelHTTPConnection,
-        request: httpcore.Request,
-    ) -> httpcore.Response:
+        request: async_mod.Request,
+    ) -> async_mod.Response:
         try:
             return await _orig_async_handle(self, request)
         except Exception:
@@ -102,8 +99,8 @@ def _patch_httpcore_proxy_tunnel():
 
     def _patched_sync_handle(
         self: sync_mod.TunnelHTTPConnection,
-        request: httpcore.Request,
-    ) -> httpcore.Response:
+        request: sync_mod.Request,
+    ) -> sync_mod.Response:
         try:
             return _orig_sync_handle(self, request)
         except Exception:


### PR DESCRIPTION
Fix https://github.com/siiway/NextBridge/pull/27#issuecomment-4839615737

```
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "NextBridge/drivers/telegram.py", line 54, in <module>
    class _HTTPXRequestCommonKwargs(TypedDict, total=False):
    ...<5 lines>...
        proxy: str | httpx.Proxy | httpx.URL | None
  File "NextBridge/drivers/telegram.py", line 60, in _HTTPXRequestCommonKwargs
    proxy: str | httpx.Proxy | httpx.URL | None
                 ^^^^^
NameError: name 'httpx' is not defined
```

## Summary by Sourcery

通过移除仅在 `TYPE_CHECKING` 中使用的 `httpx`/`httpcore` 未使用导入，并将代理隧道处理程序与异步/同步模块的请求/响应类型对齐，修复 Telegram driver 的导入和类型使用问题。

Bug Fixes:
- 通过不再依赖仅在 `TYPE_CHECKING` 中导入的 `httpx`，解决 Telegram driver 中的 `httpx` 引发的 `NameError` 问题。
- 确保 Telegram driver 中的代理隧道处理程序使用正确的异步和同步请求/响应类型，以避免运行时的类型不匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Telegram driver import and type usage issues by removing unused TYPE_CHECKING-only httpx/httpcore imports and aligning proxy tunnel handlers with async/sync module request/response types.

Bug Fixes:
- Resolve NameError for httpx in the Telegram driver by no longer relying on TYPE_CHECKING-only imports.
- Ensure proxy tunnel handlers in the Telegram driver use the correct async and sync request/response types to avoid runtime type mismatches.

</details>