### PR TITLE
feat: add general plugin system

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,9 @@ from services.http_server import HttpServerManager
 from services.media import close_all_sessions
 from services.middleware import MiddlewareChain
 from services.plugin_loader import load_all_drivers
+from plugins.context import PluginContext
+from plugins.loader import load_plugins as load_plugin_modules
+from plugins.manager import PluginManager
 
 logger = log.get_logger("__main__")
 
@@ -218,6 +221,24 @@ async def main():
     )
     bridge.command_prefix = validated_global.command_prefix
 
+    # ------------------------------------------------------------------
+    # Set up plugin infrastructure (before init_db so migrations register)
+    # ------------------------------------------------------------------
+    event_bus = EventBus()
+    middleware = MiddlewareChain()
+    bridge.set_middleware(middleware)
+    bridge.set_event_bus(event_bus)
+
+    plugin_cfg = validated_global.plugins
+    general_cfg = plugin_cfg.general
+    enabled_plugins = list(general_cfg.enabled)
+    external_plugins = general_cfg.external
+    plugin_configs = plugin_cfg.config
+
+    loaded_plugin_infos = load_plugin_modules(
+        enabled_plugins, external_plugins, plugin_cfg.paths or None
+    )
+
     try:
         init_db()
         logger.info(
@@ -232,13 +253,7 @@ async def main():
     # ------------------------------------------------------------------
     # Set up plugin infrastructure
     # ------------------------------------------------------------------
-    event_bus = EventBus()
-    middleware = MiddlewareChain()
-    bridge.set_middleware(middleware)
-    bridge.set_event_bus(event_bus)
-
     # Discover and import driver modules (built-in, entrypoints, local, external)
-    plugin_cfg = validated_global.plugins
     drivers_cfg = plugin_cfg.drivers
 
     if drivers_cfg.enabled:
@@ -327,6 +342,26 @@ async def main():
     # Let drivers perform startup and register webhook sub-apps.
     await asyncio.sleep(0)
 
+    # ------------------------------------------------------------------
+    # Initialize general plugins
+    # ------------------------------------------------------------------
+    plugin_manager = PluginManager(
+        event_bus,
+        lambda name, cfg: PluginContext(
+            bridge=bridge,
+            http_server=http_server,
+            event_bus=event_bus,
+            middleware=middleware,
+            config=cfg,
+            version=version,
+            config_path=config_path,
+        ),
+    )
+
+    await plugin_manager.discover_and_load(loaded_plugin_infos, plugin_configs)
+    for name in enabled_plugins:
+        await plugin_manager.enable_plugin(name)
+
     all_tasks: list[asyncio.Task] = []
     http_enable = validated_global.http.enable
     if http_enable == "false":
@@ -346,6 +381,7 @@ async def main():
                 )
                 return
             http_server.set_driver_manager(driver_manager, password=admin_cfg.password)
+        http_server.set_plugin_manager(plugin_manager)
         http_task = asyncio.create_task(http_server.run(), name="http/shared")
         all_tasks.append(http_task)
     else:
@@ -357,6 +393,7 @@ async def main():
         logger.info("NextBridge shutting down...")
     finally:
         await driver_manager.stop_all()
+        await plugin_manager.unload_all()
 
         for task in all_tasks:
             if not task.done():

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+
+class PluginState(Enum):
+    CREATED = auto()
+    LOADED = auto()
+    ENABLED = auto()
+    DISABLED = auto()
+    UNLOADED = auto()
+    ERROR = auto()
+
+
+@dataclass
+class PluginMeta:
+    name: str
+    version: str = "0.0.0"
+    display_name: str = ""
+    description: str = ""
+    author: str = ""
+    dependencies: list[str] = field(default_factory=list)
+
+
+class BasePlugin(ABC):
+    meta: PluginMeta = PluginMeta(name="")
+
+    async def on_load(self, ctx) -> None:
+        pass
+
+    async def on_enable(self) -> None:
+        pass
+
+    async def on_disable(self) -> None:
+        pass
+
+    async def on_unload(self) -> None:
+        pass

--- a/plugins/context.py
+++ b/plugins/context.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from services.bridge import Bridge
+    from services.event_bus import EventBus
+    from services.http_server import HttpServerManager
+    from services.middleware import MiddlewareChain
+
+
+class PluginContext:
+    def __init__(
+        self,
+        *,
+        bridge: Bridge,
+        http_server: HttpServerManager | None = None,
+        event_bus: EventBus | None = None,
+        middleware: MiddlewareChain | None = None,
+        config: dict[str, Any] | None = None,
+        version: str = "",
+        config_path: Path | None = None,
+    ) -> None:
+        self._bridge = bridge
+        self._http_server = http_server
+        self._event_bus = event_bus
+        self._middleware = middleware
+        self._config = config or {}
+        self._version = version
+        self._config_path = config_path
+
+    @property
+    def bridge(self):
+        return self._bridge
+
+    @property
+    def http_server(self):
+        return self._http_server
+
+    @property
+    def event_bus(self):
+        if self._event_bus is None:
+            from services.event_bus import EventBus
+
+            self._event_bus = EventBus()
+        return self._event_bus
+
+    @property
+    def middleware(self):
+        if self._middleware is None:
+            from services.middleware import MiddlewareChain
+
+            self._middleware = MiddlewareChain()
+        return self._middleware
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return self._config
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def config_path(self) -> Path | None:
+        return self._config_path
+
+    @property
+    def data_path(self) -> str:
+        import services.util as util
+
+        return util.get_data_path()
+
+    @staticmethod
+    def db():
+        from services.db import msg_db
+
+        return msg_db()
+
+    @staticmethod
+    def media():
+        from services import media
+
+        return media
+
+    @staticmethod
+    def logger(name: str = "", instance: bool = False):
+        import services.logger as log_mod
+
+        return log_mod.get_logger(name, instance)

--- a/plugins/context.py
+++ b/plugins/context.py
@@ -40,18 +40,10 @@ class PluginContext:
 
     @property
     def event_bus(self):
-        if self._event_bus is None:
-            from services.event_bus import EventBus
-
-            self._event_bus = EventBus()
         return self._event_bus
 
     @property
     def middleware(self):
-        if self._middleware is None:
-            from services.middleware import MiddlewareChain
-
-            self._middleware = MiddlewareChain()
         return self._middleware
 
     @property

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import services.logger as log
+
+if TYPE_CHECKING:
+    from services.config_schema import GeneralPluginEntry
+
+logger = log.get_logger("plugin_loader")
+
+ENTRYPOINT_GROUP = "nextbridge.plugins"
+
+
+@dataclass
+class PluginInfo:
+    name: str
+    source: str
+    module_path: str
+    package_name: str = ""
+    package_version: str = ""
+
+
+def discover_entrypoint_plugins() -> dict[str, PluginInfo]:
+    found: dict[str, PluginInfo] = {}
+    try:
+        eps = importlib.metadata.entry_points(group=ENTRYPOINT_GROUP)
+    except Exception:
+        return found
+
+    for ep in eps:
+        dist = getattr(ep, "dist", None)
+        found[ep.name] = PluginInfo(
+            name=ep.name,
+            source="entrypoint",
+            module_path=ep.value,
+            package_name=dist.name if dist else "",
+            package_version=dist.version if dist else "",
+        )
+    return found
+
+
+def discover_local_plugins(paths: list[str]) -> dict[str, PluginInfo]:
+    found: dict[str, PluginInfo] = {}
+    for dir_str in paths:
+        directory = Path(dir_str).resolve()
+        if not directory.is_dir():
+            logger.warning(f"Plugin path not found: {directory}")
+            continue
+        for py_file in sorted(directory.glob("*.py")):
+            if py_file.name.startswith("_"):
+                continue
+            name = py_file.stem
+            found[name] = PluginInfo(
+                name=name,
+                source="local",
+                module_path=str(py_file),
+            )
+    return found
+
+
+def discover_builtin_plugins() -> dict[str, PluginInfo]:
+    found: dict[str, PluginInfo] = {}
+    plugins_dir = Path(__file__).resolve().parent
+    for py_file in sorted(plugins_dir.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        name = py_file.stem
+        found[name] = PluginInfo(
+            name=name,
+            source="builtin",
+            module_path=f"plugins.{name}",
+        )
+    return found
+
+
+def _load_module(info: PluginInfo) -> None:
+    if info.source == "builtin":
+        if importlib.util.find_spec(info.module_path) is None:
+            logger.warning(f"Built-in plugin module '{info.name}' not found, skipping.")
+            return
+        importlib.import_module(info.module_path)
+
+    elif info.source in ("entrypoint", "external"):
+        importlib.import_module(info.module_path)
+
+    elif info.source == "local":
+        path = Path(info.module_path)
+        module_name = f"_nextbridge_plugin_{info.name}"
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            logger.error(f"Cannot load plugin from {path}")
+            return
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = mod
+        spec.loader.exec_module(mod)
+        logger.info(f"Loaded local plugin: {info.name} from {path}")
+
+
+def load_plugins(
+    enabled: list[str],
+    external: dict[str, GeneralPluginEntry],
+    paths: list[str] | None,
+) -> dict[str, PluginInfo]:
+    from services.config_schema import GeneralPluginEntry
+
+    if external is None:
+        external = {}
+
+    all_plugins: dict[str, PluginInfo] = {}
+
+    for name in enabled:
+        all_plugins[name] = PluginInfo(
+            name=name, source="builtin", module_path=f"plugins.{name}"
+        )
+
+    for name, ext_cfg in list(external.items()):
+        if isinstance(ext_cfg, dict):
+            ext_cfg = GeneralPluginEntry(**ext_cfg)
+        all_plugins[name] = PluginInfo(
+            name=name, source="external", module_path=ext_cfg.module
+        )
+
+    ep_plugins = discover_entrypoint_plugins()
+    for name, info in ep_plugins.items():
+        if name in enabled and name not in external:
+            all_plugins[name] = info
+            logger.info(
+                f"Entry-point plugin: {name} "
+                f"({info.package_name} {info.package_version})"
+            )
+
+    if paths:
+        local_plugins = discover_local_plugins(paths)
+        for name, info in local_plugins.items():
+            if name in enabled and name not in external:
+                all_plugins[name] = info
+                logger.info(f"Local plugin: {name} from {info.module_path}")
+
+    loaded: dict[str, PluginInfo] = {}
+    for name, info in all_plugins.items():
+        try:
+            _load_module(info)
+            loaded[name] = info
+        except Exception:
+            logger.opt(exception=True).error(f"Failed to load plugin: {name}")
+
+    return loaded

--- a/plugins/manager.py
+++ b/plugins/manager.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, TYPE_CHECKING
+
+import services.logger as log
+from plugins import BasePlugin, PluginState
+from plugins.registry import all_plugins as get_registered_plugins
+
+if TYPE_CHECKING:
+    from plugins.context import PluginContext
+    from plugins.loader import PluginInfo
+    from services.event_bus import EventBus
+
+logger = log.get_logger("plugin_manager")
+
+
+@dataclass
+class ManagedPlugin:
+    info: PluginInfo | None = None
+    instance: BasePlugin | None = None
+    state: PluginState = PluginState.CREATED
+    error: Exception | None = None
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+class PluginManager:
+    def __init__(
+        self,
+        event_bus: EventBus,
+        ctx_factory: Callable[[str, dict[str, Any]], PluginContext],
+    ) -> None:
+        self._managed: dict[str, ManagedPlugin] = {}
+        self._event_bus = event_bus
+        self._ctx_factory = ctx_factory
+
+    @property
+    def plugins(self) -> dict[str, ManagedPlugin]:
+        return dict(self._managed)
+
+    async def discover_and_load(
+        self,
+        loaded: dict[str, PluginInfo],
+        plugin_configs: dict[str, dict],
+    ) -> dict[str, PluginInfo]:
+        registry = get_registered_plugins()
+
+        for name, info in loaded.items():
+            plugin_cls = registry.get(name)
+            if plugin_cls is None:
+                logger.warning(
+                    f"Plugin '{name}' loaded but not registered — "
+                    f"module must call plugins.registry.register()"
+                )
+                self._managed[name] = ManagedPlugin(
+                    info=info,
+                    state=PluginState.ERROR,
+                    error=RuntimeError(f"Plugin '{name}' not registered"),
+                )
+                continue
+
+            raw_cfg = plugin_configs.get(name, {})
+            ctx = self._ctx_factory(name, raw_cfg)
+
+            try:
+                instance = plugin_cls()
+                instance.meta.name = name
+                await instance.on_load(ctx)
+                self._managed[name] = ManagedPlugin(
+                    info=info,
+                    instance=instance,
+                    state=PluginState.LOADED,
+                    config=raw_cfg,
+                )
+                logger.info(f"Plugin loaded: {name} v{instance.meta.version}")
+                self._event_bus.emit("plugin.loaded", name=name)
+            except Exception as exc:
+                logger.opt(exception=True).error(f"Failed to load plugin: {name}")
+                self._managed[name] = ManagedPlugin(
+                    info=info, state=PluginState.ERROR, error=exc, config=raw_cfg
+                )
+                self._event_bus.emit("plugin.error", name=name, error=exc)
+
+        return loaded
+
+    async def enable_plugin(self, name: str) -> None:
+        managed = self._managed.get(name)
+        if managed is None:
+            logger.warning(f"Cannot enable unknown plugin: {name}")
+            return
+        if managed.state != PluginState.LOADED:
+            logger.warning(
+                f"Cannot enable plugin '{name}' in state {managed.state.name}"
+            )
+            return
+        if managed.instance is None:
+            return
+
+        try:
+            await managed.instance.on_enable()
+            managed.state = PluginState.ENABLED
+            logger.info(f"Plugin enabled: {name}")
+            self._event_bus.emit("plugin.enabled", name=name)
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Failed to enable plugin: {name}")
+            managed.state = PluginState.ERROR
+            managed.error = exc
+            self._event_bus.emit("plugin.error", name=name, error=exc)
+
+    async def disable_plugin(self, name: str) -> None:
+        managed = self._managed.get(name)
+        if managed is None:
+            return
+        if managed.state != PluginState.ENABLED:
+            return
+        if managed.instance is None:
+            return
+
+        try:
+            await managed.instance.on_disable()
+            managed.state = PluginState.DISABLED
+            logger.info(f"Plugin disabled: {name}")
+            self._event_bus.emit("plugin.disabled", name=name)
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Failed to disable plugin: {name}")
+            managed.state = PluginState.ERROR
+            managed.error = exc
+            self._event_bus.emit("plugin.error", name=name, error=exc)
+
+    async def reload_plugin(self, name: str) -> None:
+        managed = self._managed.get(name)
+        if managed is None:
+            logger.warning(f"Cannot reload unknown plugin: {name}")
+            return
+
+        if managed.state == PluginState.ENABLED:
+            await self.disable_plugin(name)
+
+        if managed.instance is not None:
+            try:
+                await managed.instance.on_unload()
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Error during unload of plugin '{name}'"
+                )
+
+        registry = get_registered_plugins()
+        plugin_cls = registry.get(name)
+        if plugin_cls is None:
+            logger.error(f"Cannot reload plugin '{name}': not in registry")
+            managed.state = PluginState.ERROR
+            managed.error = RuntimeError(f"Plugin '{name}' not in registry")
+            return
+
+        raw_cfg = managed.config
+
+        ctx = self._ctx_factory(name, raw_cfg)
+
+        try:
+            instance = plugin_cls()
+            instance.meta.name = name
+            await instance.on_load(ctx)
+            managed.instance = instance
+            managed.state = PluginState.LOADED
+            managed.error = None
+            logger.info(f"Plugin reloaded: {name}")
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Failed to reload plugin: {name}")
+            managed.state = PluginState.ERROR
+            managed.error = exc
+            self._event_bus.emit("plugin.error", name=name, error=exc)
+
+    async def unload_plugin(self, name: str) -> None:
+        managed = self._managed.get(name)
+        if managed is None:
+            return
+
+        if managed.state == PluginState.ENABLED:
+            await self.disable_plugin(name)
+
+        if managed.instance is not None:
+            try:
+                await managed.instance.on_unload()
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Error during unload of plugin '{name}'"
+                )
+
+        managed.state = PluginState.UNLOADED
+        managed.instance = None
+        logger.info(f"Plugin unloaded: {name}")
+
+    def get_status(self) -> dict[str, dict[str, Any]]:
+        return {
+            name: {
+                "state": m.state.name,
+                "version": (m.instance.meta.version if m.instance else "unknown"),
+                "error": str(m.error) if m.error else None,
+                "source": m.info.source if m.info else "unknown",
+            }
+            for name, m in self._managed.items()
+        }
+
+    async def unload_all(self) -> None:
+        for name in list(self._managed):
+            await self.unload_plugin(name)

--- a/plugins/registry.py
+++ b/plugins/registry.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plugins import BasePlugin
+
+_REGISTRY: dict[str, type[BasePlugin]] = {}
+
+
+def register(name: str, plugin_cls: type[BasePlugin]) -> None:
+    _REGISTRY[name] = plugin_cls
+
+
+def unregister(name: str) -> bool:
+    return _REGISTRY.pop(name, None) is not None
+
+
+def all_plugins() -> dict[str, type[BasePlugin]]:
+    return dict(_REGISTRY)
+
+
+def get_plugin(name: str) -> type[BasePlugin] | None:
+    return _REGISTRY.get(name)

--- a/plugins/stats.py
+++ b/plugins/stats.py
@@ -23,20 +23,17 @@ class StatsPlugin(BasePlugin):
         self._counts[platform] = self._counts.get(platform, 0) + 1
 
     async def _handle_stats(self, msg, args) -> None:
-        sender_info = self._bridge._senders.get(msg.instance_id)
-        if not sender_info:
-            return
-        _, sender = sender_info
-
         if not self._counts:
-            await sender(msg.channel, "No bridged messages recorded yet.")
+            await self._bridge.send_message(
+                msg.instance_id, msg.channel, "No bridged messages recorded yet."
+            )
             return
 
         total = sum(self._counts.values())
         lines = [f"Bridged messages: {total}"]
         for platform, count in sorted(self._counts.items()):
             lines.append(f"- {platform}: {count}")
-        await sender(msg.channel, "\n".join(lines))
+        await self._bridge.send_message(msg.instance_id, msg.channel, "\n".join(lines))
 
     async def on_enable(self) -> None:
         self._ctx.event_bus.on("bridge.message", self._on_message)
@@ -44,6 +41,7 @@ class StatsPlugin(BasePlugin):
 
     async def on_disable(self) -> None:
         self._ctx.event_bus.off("bridge.message", self._on_message)
+        self._bridge.unregister_command("stats")
 
 
 register("stats", StatsPlugin)

--- a/plugins/stats.py
+++ b/plugins/stats.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from plugins import BasePlugin, PluginMeta
+from plugins.registry import register
+
+
+class StatsPlugin(BasePlugin):
+    meta = PluginMeta(
+        name="stats",
+        version="1.0.0",
+        display_name="Message Stats",
+        description="Count bridged messages and report via /<prefix> stats",
+        author="NextBridge",
+    )
+
+    async def on_load(self, ctx) -> None:
+        self._ctx = ctx
+        self._counts: dict[str, int] = {}
+        self._bridge = ctx.bridge
+
+    async def _on_message(self, instance_id: str, **kwargs) -> None:
+        platform = kwargs.get("platform") or "unknown"
+        self._counts[platform] = self._counts.get(platform, 0) + 1
+
+    async def _handle_stats(self, msg, args) -> None:
+        sender_info = self._bridge._senders.get(msg.instance_id)
+        if not sender_info:
+            return
+        _, sender = sender_info
+
+        if not self._counts:
+            await sender(msg.channel, "No bridged messages recorded yet.")
+            return
+
+        total = sum(self._counts.values())
+        lines = [f"Bridged messages: {total}"]
+        for platform, count in sorted(self._counts.items()):
+            lines.append(f"- {platform}: {count}")
+        await sender(msg.channel, "\n".join(lines))
+
+    async def on_enable(self) -> None:
+        self._ctx.event_bus.on("bridge.message", self._on_message)
+        self._bridge.register_command("stats", self._handle_stats)
+
+    async def on_disable(self) -> None:
+        self._ctx.event_bus.off("bridge.message", self._on_message)
+
+
+register("stats", StatsPlugin)

--- a/services/bridge.py
+++ b/services/bridge.py
@@ -62,6 +62,7 @@ class Bridge:
         self._deleters: dict[str, Callable] = {}
         self._pinners: dict[str, Callable] = {}
         self._unpinners: dict[str, Callable] = {}
+        self._commands: dict[str, Callable] = {}
         self._sensitive: frozenset[str] = frozenset()
         self._middleware: MiddlewareChain | None = None
         self._event_bus: EventBus | None = None
@@ -172,6 +173,10 @@ class Bridge:
         self._unpinners[instance_id] = unpin_func
         logger.debug(f"Registered unpinner for instance: {instance_id}")
 
+    def register_command(self, name: str, handler: Callable) -> None:
+        self._commands[name] = handler
+        logger.debug(f"Registered command: {name}")
+
     def senders_snapshot(self) -> list[dict]:
         """Return a serialisable snapshot of registered senders."""
         return [
@@ -189,10 +194,13 @@ class Bridge:
 
     def _get_command_help(self) -> str:
         prefix = self._get_command_prefix()
-        return (
+        lines = [
             f"Usage: `/{prefix} bind setup`, `/{prefix} bind confirm <code>`, "
-            f"`/{prefix} bind rm [instance_id]`, `/{prefix} bind list`, `/ping <target>`"
-        )
+            f"`/{prefix} bind rm [instance_id]`, `/{prefix} bind list`, `/ping <target>`",
+        ]
+        for name in self._commands:
+            lines.append(f"`/{prefix} {name}`")
+        return "\n".join(lines)
 
     def _parse_ping_command(self, text: str) -> str | None:
         parts = text.strip().split(maxsplit=1)
@@ -376,6 +384,22 @@ class Bridge:
         command = self._parse_internal_command(msg.text)
         if command is not None:
             action, args = command
+            if action in self._commands:
+                if not self._is_allowed_command_source(msg) and not msg.is_dm:
+                    logger.debug(
+                        f"Ignored command from non-configured channel: "
+                        f"instance={msg.instance_id} channel={msg.channel}"
+                    )
+                    return
+                handler = self._commands[action]
+                try:
+                    await handler(msg, args)
+                except Exception:
+                    logger.opt(exception=True).error(
+                        f"Error executing registered command '{action}'"
+                    )
+                return
+
             if not self._is_allowed_command_source(msg):
                 if action != "bind" or not msg.is_dm:
                     logger.debug(

--- a/services/bridge.py
+++ b/services/bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import services.logger as log
@@ -11,6 +11,8 @@ from services import config, cqface
 from services.db import msg_db
 from services.message import NormalizedMessage
 from services.message_format import parse_richheader_tag
+
+CommandHandler = Callable[..., Awaitable[None]]
 
 if TYPE_CHECKING:
     from services.event_bus import EventBus
@@ -62,7 +64,7 @@ class Bridge:
         self._deleters: dict[str, Callable] = {}
         self._pinners: dict[str, Callable] = {}
         self._unpinners: dict[str, Callable] = {}
-        self._commands: dict[str, Callable] = {}
+        self._commands: dict[str, CommandHandler] = {}
         self._sensitive: frozenset[str] = frozenset()
         self._middleware: MiddlewareChain | None = None
         self._event_bus: EventBus | None = None
@@ -173,9 +175,23 @@ class Bridge:
         self._unpinners[instance_id] = unpin_func
         logger.debug(f"Registered unpinner for instance: {instance_id}")
 
-    def register_command(self, name: str, handler: Callable) -> None:
+    def register_command(self, name: str, handler: CommandHandler) -> None:
         self._commands[name] = handler
         logger.debug(f"Registered command: {name}")
+
+    def unregister_command(self, name: str) -> None:
+        self._commands.pop(name, None)
+        logger.debug(f"Unregistered command: {name}")
+
+    async def send_message(
+        self, instance_id: str, channel: dict, text: str, **kwargs
+    ) -> str | list[str] | None:
+        sender_info = self._senders.get(instance_id)
+        if sender_info is None:
+            logger.warning(f"No sender for instance '{instance_id}'")
+            return None
+        _, sender = sender_info
+        return await sender(channel, text, **kwargs)
 
     def senders_snapshot(self) -> list[dict]:
         """Return a serialisable snapshot of registered senders."""

--- a/services/config_schema.py
+++ b/services/config_schema.py
@@ -204,6 +204,38 @@ class ExternalDriverConfig(BaseModel):
     """Python module path to import, e.g. ``"nextbridge_mycustom.driver"``."""
 
 
+class GeneralPluginEntry(BaseModel):
+    """Configuration for an external general plugin loaded from a pip package or file.
+
+    The plugin module must call ``plugins.registry.register()`` at import
+    time — the same contract as built-in plugins.
+
+    Example::
+
+        global:
+          plugins:
+            general:
+              enabled:
+                - stats
+              external:
+                my_plugin:
+                  module: "nextbridge_myplugin"
+    """
+
+    module: str
+    """Python module path to import, e.g. ``"nextbridge_myplugin"``."""
+
+
+class GeneralPluginConfig(BaseModel):
+    """General (non-driver) plugin selection configuration."""
+
+    enabled: list[str] = []
+    """Plugin names to enable. Empty = no general plugins."""
+
+    external: dict[str, GeneralPluginEntry] = {}
+    """External plugin imports, keyed by plugin name."""
+
+
 class DriversConfig(BaseModel):
     """Driver selection configuration.
 
@@ -233,6 +265,12 @@ class PluginConfig(BaseModel):
 
     drivers: DriversConfig = DriversConfig()
     """Driver selection and external driver configuration."""
+
+    general: GeneralPluginConfig = GeneralPluginConfig()
+    """General (non-driver) plugin selection configuration."""
+
+    config: dict[str, dict] = {}
+    """Per-plugin configuration, keyed by plugin name."""
 
     auto_restart: CoercedBool = True
     """Automatically restart crashed drivers with exponential backoff."""

--- a/services/db.py
+++ b/services/db.py
@@ -105,7 +105,7 @@ class MessageDB:
     """Handles mapping of message IDs between different platforms."""
 
     _SCHEMA_VERSION = max(
-        (step.to_version for step in db_migrations.MIGRATIONS), default=0
+        (step.to_version for step in db_migrations.get_migrations()), default=0
     )
 
     @classmethod
@@ -247,7 +247,7 @@ class MessageDB:
     @staticmethod
     @lru_cache(maxsize=1)
     def _load_migration_steps() -> tuple[MigrationStep, ...]:
-        steps = db_migrations.MIGRATIONS
+        steps = db_migrations.get_migrations()
         logger.debug(f"Loaded {len(steps)} migration step(s) from registry")
         return steps
 

--- a/services/db_migrations.py
+++ b/services/db_migrations.py
@@ -22,6 +22,9 @@ class MigrationStep:
 _MIGRATION_FILE_RE = re.compile(r"^(\d+)-(\d+)\.py$")
 
 
+_PLUGIN_MIGRATIONS: list[MigrationStep] = []
+
+
 def _discover_migrations() -> tuple[MigrationStep, ...]:
     migrations_dir = Path(__file__).resolve().parent / "migrations"
     steps: list[MigrationStep] = []
@@ -47,6 +50,22 @@ def _discover_migrations() -> tuple[MigrationStep, ...]:
 
     steps.sort(key=lambda s: (s.from_version, s.to_version, s.file_path.name))
     return tuple(steps)
+
+
+def get_migrations() -> tuple[MigrationStep, ...]:
+    return _discover_migrations() + tuple(_PLUGIN_MIGRATIONS)
+
+
+def register_plugin_migration(
+    from_version: int, to_version: int, file_path: Path
+) -> None:
+    _PLUGIN_MIGRATIONS.append(
+        MigrationStep(
+            from_version=from_version,
+            to_version=to_version,
+            file_path=file_path,
+        )
+    )
 
 
 MIGRATIONS: tuple[MigrationStep, ...] = _discover_migrations()

--- a/services/event_bus.py
+++ b/services/event_bus.py
@@ -25,6 +25,10 @@ class EventBus:
         driver.stopped    (instance_id)
         driver.abandoned  (instance_id)
         health_changed    (driver, old, new)
+        plugin.loaded     (name)
+        plugin.enabled    (name)
+        plugin.disabled   (name)
+        plugin.error      (name, error)
     """
 
     def __init__(self) -> None:

--- a/services/http_server.py
+++ b/services/http_server.py
@@ -16,6 +16,7 @@ import services.logger as log
 
 if TYPE_CHECKING:
     from services.driver_manager import DriverManager
+    from plugins.manager import PluginManager
 
 logger = log.get_logger("http")
 
@@ -87,6 +88,7 @@ class HttpServerManager:
         self._ready = asyncio.Event()
         self._started = False
         self._driver_manager: DriverManager | None = None
+        self._plugin_manager: PluginManager | None = None
         self._admin_password: str = ""
 
     @staticmethod
@@ -119,6 +121,9 @@ class HttpServerManager:
     def set_driver_manager(self, manager: DriverManager, *, password: str) -> None:
         self._driver_manager = manager
         self._admin_password = password
+
+    def set_plugin_manager(self, manager: PluginManager) -> None:
+        self._plugin_manager = manager
 
     def has_mounts(self) -> bool:
         return bool(self._mounts)
@@ -188,8 +193,22 @@ class HttpServerManager:
                 return JSONResponse({"status": "restarted", "instance_id": instance_id})
 
             logger.info(
-                "Admin API enabled (/_nextbridge/drivers, /_nextbridge/admin/*)"
+                "Admin API enabled (/_nextbridge/drivers, /_nextbridge/plugins, /_nextbridge/admin/*)"
             )
+
+        if self._plugin_manager is not None:
+
+            @root.get(
+                "/_nextbridge/plugins",
+                dependencies=[Depends(self._check_admin_auth)],
+            )
+            async def _plugins_status() -> JSONResponse:
+                pm = self._plugin_manager
+                if pm is None:
+                    raise HTTPException(
+                        status_code=503, detail="Plugin manager not available"
+                    )
+                return JSONResponse({"plugins": pm.get_status()})
 
         for mount in self._mounts:
             root.mount(mount.path, mount.app)


### PR DESCRIPTION
- Add plugins/ package with BasePlugin, PluginMeta, PluginState
- Add PluginRegistry for import-time registration
- Add PluginContext as service facade for plugins
- Add PluginLoader with 4-source discovery (builtin/entrypoint/external/local)
- Add PluginManager for lifecycle management (load/enable/disable/reload/unload)
- Extend PluginConfig with GeneralPluginConfig and per-plugin config
- Add register_command() to Bridge for user-command plugins
- Add register_plugin_migration() for custom DB migrations
- Add /_nextbridge/plugins admin API endpoint
- Add plugin lifecycle events to EventBus (loaded/enabled/disabled/error)
- Add stats example plugin
- Integrate PluginManager into main.py startup flow

## Summary by Sourcery

为非驱动扩展引入通用插件架构，并将其集成到应用的启动、运行时以及关闭流程中。

新功能：
- 添加 `plugins` 包，提供基础插件抽象、注册表、生命周期状态以及用于访问核心服务的上下文对象。
- 添加 `PluginLoader` 和 `PluginManager`，用于从多种来源（内置、入口点、外部、本地）发现、加载、启用、禁用、重新加载和卸载插件。
- 扩展配置，以支持通用插件、外部插件声明以及每个插件的配置数据。
- 暴露新的 HTTP 管理端点，用于检查插件状态和元数据。
- 通过 Bridge 命令注册支持面向用户的命令插件，并提供一个示例统计插件，用于报告桥接消息计数。
- 允许插件注册自定义数据库迁移，并将其纳入模式版本控制。

改进：
- 将插件系统接入主启动流程，在数据库迁移之前初始化插件，并在驱动组件旁边管理其生命周期。
- 在 `EventBus` 上发出插件生命周期事件，以提升可观测性并方便与其他组件集成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a general-purpose plugin architecture for non-driver extensions and integrate it into application startup, runtime, and shutdown flows.

New Features:
- Add a plugins package with base plugin abstractions, registry, lifecycle states, and a context object for accessing core services.
- Add a PluginLoader and PluginManager to discover, load, enable, disable, reload, and unload plugins from multiple sources (builtin, entrypoint, external, local).
- Extend configuration to support general plugins, external plugin declarations, and per-plugin configuration data.
- Expose a new HTTP admin endpoint to inspect plugin status and metadata.
- Add support for user-facing command plugins via Bridge command registration and a sample stats plugin that reports bridged message counts.
- Allow plugins to register custom database migrations that are included in schema versioning.

Enhancements:
- Wire the plugin system into main startup to initialize plugins before database migrations and to manage their lifecycle alongside drivers.
- Emit plugin lifecycle events on the EventBus for observability and integration with other components.

</details>